### PR TITLE
change 'scrollPosition' to b'scrollPosition'

### DIFF
--- a/mdviewer.py
+++ b/mdviewer.py
@@ -172,7 +172,7 @@ class App(QtWidgets.QMainWindow):
     def _scroll(self, element):
         '''Scroll to the top of the element.'''
 
-        self.anim = QtCore.QPropertyAnimation(self.curr_doc, 'scrollPosition')
+        self.anim = QtCore.QPropertyAnimation(self.curr_doc, b'scrollPosition')
         start = self.curr_doc.scrollPosition()
 
         self.anim.setDuration(250)


### PR DESCRIPTION
QPropertyAnimation requires a QByteArray, in my case when I want to move to another point the program crashed.